### PR TITLE
Make Chrome path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# Catching Shifts
+
+A collection of scripts used to interact with the SkipTheDishes courier APIs. Some utilities rely on launching a local installation of Chrome or Chromium via Pyppeteer.
+
+## Environment Variables
+
+- **PUPPETEER_EXECUTABLE_PATH**: Absolute path to the Chrome/Chromium executable used by the `auth_code_capture.py` script. Set this variable before running the script so it can locate your browser.
+

--- a/bot_manager/auth_code_capture.py
+++ b/bot_manager/auth_code_capture.py
@@ -11,10 +11,16 @@ from pyppeteer.connection import Connection  # Add this import
 from pyppeteer_stealth import stealth
 from config import save_last_user_id, AUTH_DIR
 
-CHROME_PATH = r"C:\Users\gusta\OneDrive\Desktop\chrome-win\chrome.exe"
+# Read Chrome/Chromium executable path from environment. This allows the
+# script to run on different systems without hard-coding a location.
+CHROME_PATH = os.environ.get("PUPPETEER_EXECUTABLE_PATH")
 
 def verify_chrome_path():
     """Verify Chrome executable exists and is runnable"""
+    if not CHROME_PATH:
+        print("❌ Environment variable 'PUPPETEER_EXECUTABLE_PATH' is not set")
+        return False
+
     if not os.path.exists(CHROME_PATH):
         print(f"❌ Chrome not found at: {CHROME_PATH}")
         return False


### PR DESCRIPTION
## Summary
- read Chrome path from `PUPPETEER_EXECUTABLE_PATH`
- validate the env var in `verify_chrome_path`
- document the env variable in a new README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6847810ac8648323839a8a04da7489a9