### PR TITLE
Fix Flask template path

### DIFF
--- a/bot_manager/app.py
+++ b/bot_manager/app.py
@@ -54,8 +54,8 @@ REDIRECT_URI       = os.getenv("REDIRECT_URI", "http://localhost:5000/callback")
 # ────────────────────────────────────────────────────────────────────────────────
 # 4) Configuração do Flask, definindo onde estão templates e estáticos
 # ────────────────────────────────────────────────────────────────────────────────
-# Agora assumimos que a pasta 'templates/' e 'static/' estão em catchingShifts/, um nível acima de bot_manager/.
-base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), os.pardir))
+# As pastas de templates e arquivos estáticos ficam dentro de bot_manager/
+base_dir = os.path.dirname(os.path.abspath(__file__))
 app = Flask(
     __name__,
     template_folder=os.path.join(base_dir, "templates"),


### PR DESCRIPTION
## Summary
- point Flask to templates and static directories inside `bot_manager`

## Testing
- `pip install -r requirements.txt`
- `python bot_manager/app.py` (verified server starts)

------
https://chatgpt.com/codex/tasks/task_e_68479812379c8323876cdf5e547e2740