### PR TITLE
Fix login redirect for mobile flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ python bot_manager/app.py
 ```
 
 The application starts a local web server at `http://127.0.0.1:5000/`.
-Use the **Connect** button to authenticate. Tokens are stored in `userauth/`.
+Use the **Connect** button to authenticate. By default the login flow mimics
+the official mobile app and uses the `courierapp://homepage` redirect URI.
+If necessary, you can override this with the `REDIRECT_URI` environment
+variable. Tokens are stored in `userauth/`.
 
 To run the individual authorization flow from the terminal you can also run:
 

--- a/bot_manager/app.py
+++ b/bot_manager/app.py
@@ -49,7 +49,9 @@ KEYCLOAK_TOKEN_URL = os.getenv(
     "https://api-produk.skipthedishes.com/auth/realms/Courier/protocol/openid-connect/token"
 )
 CLIENT_ID          = os.getenv("CLIENT_ID", "courier_mobile_jet_uk")
-REDIRECT_URI       = os.getenv("REDIRECT_URI", "http://localhost:5000/callback")
+# Default redirect URI matches the official mobile app so the login page
+# is served without Keycloak rejecting our request.
+REDIRECT_URI       = os.getenv("REDIRECT_URI", "courierapp://homepage")
 
 # ────────────────────────────────────────────────────────────────────────────────
 # 4) Configuração do Flask, definindo onde estão templates e estáticos
@@ -194,7 +196,9 @@ def connect():
         "redirect_uri":  REDIRECT_URI,
         "response_type": "code",
         "scope":         "openid profile email offline_access",
-        "response_mode": "query",
+        # Use fragment to match the mobile app flow and allow interception of
+        # the authorization code from the "courierapp://" redirect.
+        "response_mode": "fragment",
         "state":         state,
         "prompt":        "login"
     }


### PR DESCRIPTION
## Summary
- use the mobile app redirect URI by default
- mention `REDIRECT_URI` in the docs
- align `/connect` with the mobile login flow

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68479b0107008323be3bf7deb55fbba4